### PR TITLE
Add dtl as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = depend/BehaviorTree.CPP
 	url = https://github.com/BehaviorTree/BehaviorTree.CPP/
 	branch = ver_3
+[submodule "dtl"]
+	path = dtl
+	url = https://github.com/uml-robotics/dtl


### PR DESCRIPTION
Using this command: `git submodule add https://github.com/uml-robotics/dtl dtl`

The readme already has this instruction to pull dtl:  `git submodule update --init --recursive`